### PR TITLE
power_down_device

### DIFF
--- a/relay/workflow.py
+++ b/relay/workflow.py
@@ -446,4 +446,11 @@ class Relay:
             'restart': True
         }
         await self.sendReceive(event)
+    
+    async def power_down_device(self):
+        event = {
+            '_type': 'wf_api_device_power_off_request',
+            'restart': False
+        }
+        await self.sendReceive(event)
 

--- a/tests/all_features.py
+++ b/tests/all_features.py
@@ -55,7 +55,9 @@ async def start_handler(relay):
     incident_id = await relay.create_incident('i')
     await relay.resolve_incident(incident_id, 'r')
 
-    await relay.restart_device()  
+    await relay.restart_device()
+
+    await relay.power_down_device()  
 
     await relay.terminate()
 

--- a/tests/test_all_features.py
+++ b/tests/test_all_features.py
@@ -312,6 +312,14 @@ async def handle_restart_device(ws):
         '_id': e['_id'],
         '_type': 'wf_api_device_power_off_response'})
 
+async def handle_power_down_device(ws):
+    e = await recv(ws)
+    check(e, 'wf_api_device_power_off_request')
+
+    await send(ws, {
+        '_id': e['_id'],
+        '_type': 'wf_api_device_power_off_response'})
+
 
 async def simple():
     uri = "ws://localhost:8765/hello"
@@ -380,6 +388,7 @@ async def simple():
         await handle_resolve_incident(ws, 'iid', 'r')
 
         await handle_restart_device(ws)
+        await handle_power_down_device(ws)
 
         await handle_terminate(ws)
 


### PR DESCRIPTION
Add functionality for powering down the device without restart. Very similar to #2, the only change being the `restart` value being set to `False`.

Basis: (From relay-js sdk `index.ts line 217-219`):
<img width="603" alt="Screen Shot 2021-06-23 at 4 25 20 PM" src="https://user-images.githubusercontent.com/7386679/123163358-a323e980-d43f-11eb-9254-77e62975733a.png">

1 test added -> test passing
