### PR TITLE
stop_playback

### DIFF
--- a/relay/workflow.py
+++ b/relay/workflow.py
@@ -454,7 +454,7 @@ class Relay:
         }
         await self.sendReceive(event)
     
-    async def stop_playback(self, id):
+    async def stop_playback(self, id=None):
         event = None
         if type(id) == list:
             event = {
@@ -467,7 +467,7 @@ class Relay:
                 '_type': 'wf_api_stop_playback_request',
                 'ids': id
             }
-        else:
+        elif id is None:
             event = {
                 '_type': 'wf_api_stop_playback_request'
             }

--- a/tests/all_features.py
+++ b/tests/all_features.py
@@ -61,7 +61,7 @@ async def start_handler(relay):
 
     await relay.stop_playback('1839')
     await relay.stop_playback(['1839', '1840', '1850', '1860'])
-    await relay.stop_playback(37)
+    await relay.stop_playback()
 
     await relay.terminate()
 

--- a/tests/test_all_features.py
+++ b/tests/test_all_features.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import asyncio
-from inspect import isdatadescriptor
 import json
 import pytest
 import websockets
@@ -321,32 +320,17 @@ async def handle_power_down_device(ws):
         '_id': e['_id'],
         '_type': 'wf_api_device_power_off_response'})
 
-async def handle_stop_playback_single(ws, xid):
+async def handle_stop_playback(ws, xid=None):
     e = await recv(ws)
-    check(e, 'wf_api_stop_playback_request', ids=xid)
+    if xid:
+        check(e, 'wf_api_stop_playback_request', ids=xid)
+    else:
+        check(e, 'wf_api_stop_playback_request')
 
     await send(ws, {
         '_id': e['_id'],
         '_type': 'wf_api_stop_playback_response',
         'ids': xid})
-
-async def handle_stop_playback_multiple(ws, xid):
-    e = await recv(ws)
-    check(e, 'wf_api_stop_playback_request', ids=xid)
-
-    await send(ws, {
-        '_id': e['_id'],
-        '_type': 'wf_api_stop_playback_response',
-        'ids': xid})
-
-async def handle_stop_playback_none(ws):
-    e = await recv(ws)
-    check(e, 'wf_api_stop_playback_request')
-
-    await send(ws, {
-        '_id': e['_id'],
-        '_type': 'wf_api_stop_playback_response'})
-
 
 async def simple():
     uri = "ws://localhost:8765/hello"
@@ -417,9 +401,9 @@ async def simple():
         await handle_restart_device(ws)
         await handle_power_down_device(ws)
 
-        await handle_stop_playback_single(ws, ['1839'])
-        await handle_stop_playback_multiple(ws, ['1839', '1840', '1850', '1860'])
-        await handle_stop_playback_none(ws)
+        await handle_stop_playback(ws, ['1839'])
+        await handle_stop_playback(ws, ['1839', '1840', '1850', '1860'])
+        await handle_stop_playback(ws)
 
         await handle_terminate(ws)
 


### PR DESCRIPTION
Add stop_playback functionality for relay-py sdk.

Basis: (from Relay-js sdk `Index.ts line 231-239`)
<img width="609" alt="Screen Shot 2021-06-24 at 10 03 14 AM" src="https://user-images.githubusercontent.com/7386679/123277414-1414e100-d4d4-11eb-824e-9369c8bbb3d9.png">


3 types for this: if someone passes in 

- single id, 
- an array of ids 
- an id not in the format of string or list

Added tests for all 3 scenarios.
Tests passing