### PR TITLE
UPDATE `label` to `name`

### DIFF
--- a/relay/workflow.py
+++ b/relay/workflow.py
@@ -317,8 +317,7 @@ class Relay:
         await self.sendReceive(event)
 
 
-    async def get_device_label(self):
-        # TODO: ibot will change to label at some point; change here to match
+    async def get_device_name(self):
         v = await self._get_device_info('name', False)
         return v['name']
 
@@ -348,8 +347,8 @@ class Relay:
         return v
 
 
-    async def set_device_label(self, label):
-        await self._set_device_info('label', label)
+    async def set_device_name(self, name):
+        await self._set_device_info('label', name)
 
     async def set_device_channel(self, channel: str):
         await self._set_device_info('channel', channel)

--- a/tests/all_features.py
+++ b/tests/all_features.py
@@ -26,13 +26,13 @@ async def start_handler(relay):
 
     await relay.set_channel('c', ['d1', 'd2'])
 
-    await relay.get_device_label()
+    await relay.get_device_name()
     await relay.get_device_address()
     await relay.get_device_latlong()
     await relay.get_device_indoor_location()
     await relay.get_device_battery()
 
-    await relay.set_device_label('n')
+    await relay.set_device_name('n')
     await relay.set_device_channel('c')
 
     await relay.set_led_on('00FF00')

--- a/tests/test_all_features.py
+++ b/tests/test_all_features.py
@@ -149,8 +149,8 @@ async def handle_set_channel(ws, xchannel_name, xtarget):
         '_type': 'wf_api_set_channel_response'})
 
 
-async def handle_get_device_label(ws, xrefresh, label):
-    await _handle_get_device_info(ws, 'name', xrefresh, name=label)
+async def handle_get_device_name(ws, xrefresh, name):
+    await _handle_get_device_info(ws, 'name', xrefresh, name=name)
  
 async def handle_get_device_address(ws, xrefresh, address):
     await _handle_get_device_info(ws, 'address', xrefresh, address=address)
@@ -174,7 +174,7 @@ async def _handle_get_device_info(ws, xquery, xrefresh, **kwargs):
         **kwargs})
 
 
-async def handle_set_device_label(ws, xvalue):
+async def handle_set_device_name(ws, xvalue):
     await _handle_set_device_info(ws, 'label', xvalue)
 
 async def handle_set_device_channel(ws, xvalue):
@@ -292,7 +292,7 @@ async def send_timer(ws):
 
 
 
-async def handle_set_device_label(ws, xvalue):
+async def handle_set_device_name(ws, xvalue):
     await _handle_set_device_info(ws, 'label', xvalue)
 
 async def _handle_set_device_info(ws, xfield, xvalue):
@@ -353,7 +353,7 @@ async def simple():
 
         await handle_set_channel(ws, 'c', ['d1', 'd2'])
 
-        await handle_get_device_label(ws, False, 't')
+        await handle_get_device_name(ws, False, 't')
         await handle_get_device_address(ws, False, 'a')
         await handle_get_device_latlong(ws, False, [1,2])
         await handle_get_device_indoor_location(ws, False, 'l')


### PR DESCRIPTION
IBOT changed its convention from using `label` to `name`
Changed all occurrences of labels to names. 


One exception is that in the `set_device_name` function, I've noticed that the Relay-JS SDK is still using the tag `label` to retrieve the name, so I won't be altering that for now.
Basis for exception case ( from Relay-JS SDK `Index.ts line 327-329`):
<img width="577" alt="Screen Shot 2021-06-28 at 4 36 22 PM" src="https://user-images.githubusercontent.com/7386679/123700869-0f7f5e00-d82f-11eb-97b3-4fa89c983823.png">

Tests:

- Tests altered but no new tests added -> passing