### PR TITLE
set_device_mode

### DIFF
--- a/relay/workflow.py
+++ b/relay/workflow.py
@@ -366,11 +366,11 @@ class Relay:
         v = await self.sendReceive(event)
         return event
 
-    async def set_device_mode(self, mode, targets):
+    async def set_device_mode(self, mode, target=None):
         event = {
             '_type': 'wf_api_set_device_mode_request',
             'mode': mode,
-            'target': targets
+            'target': target
         }
         await self.sendReceive(event)
 

--- a/tests/all_features.py
+++ b/tests/all_features.py
@@ -35,6 +35,7 @@ async def start_handler(relay):
 
     await relay.set_device_name('n')
     await relay.set_device_channel('c')
+    await relay.set_device_mode('m')
     await relay.set_device_mode('m', ['d1', 'd2'])
 
     await relay.set_led_on('00FF00')

--- a/tests/test_all_features.py
+++ b/tests/test_all_features.py
@@ -192,9 +192,12 @@ async def _handle_set_device_info(ws, xfield, xvalue):
         '_type': 'wf_api_set_device_info_response',
     })
 
-async def handle_set_device_mode(ws, xmode, xtargets):
+async def handle_set_device_mode(ws, xmode, xtarget=None):
     e = await recv(ws)
-    check(e, 'wf_api_set_device_mode_request', mode=xmode, target=xtargets)
+    if xtarget:
+        check(e, 'wf_api_set_device_mode_request', mode=xmode, target=xtarget)
+    else:
+        check(e, 'wf_api_set_device_mode_request', mode=xmode)
 
     await send(ws, {
         '_id': e['_id'],
@@ -406,6 +409,7 @@ async def simple():
 
         await handle_set_device_channel(ws, 'c')
 
+        await handle_set_device_mode(ws, 'm')
         await handle_set_device_mode(ws, 'm', ['d1', 'd2'])
 
         await handle_set_led_on(ws, '00FF00')


### PR DESCRIPTION
Setter for relay device mode.

Basis: (from Relay-js sdk `index.ts line 336-338`):
<img width="779" alt="Screen Shot 2021-07-13 at 1 15 58 PM" src="https://user-images.githubusercontent.com/7386679/125496767-c1fe767d-560c-403a-aa97-e184f2ed6707.png">

Tests:

- Test with device mode set to `m` on targets `d1` and `d2` -> test passing
- Test with device mode set to `m` with no targets -> test passing

Note:
on line [373](https://github.com/relaypro/relay-py/blob/3ae2abd6cca6f8a49dd4b02bc030b7e966f4d70f/relay/workflow.py#L373) in this pr, I'm referencing an array of targets as `target`. Based off the the JS sdk, `target` seems to be an array of targets as well. 