### PR TITLE
place_call

### DIFF
--- a/relay/workflow.py
+++ b/relay/workflow.py
@@ -513,9 +513,16 @@ class Relay:
         translatedText = await self.sendReceive(event)
         return translatedText
 
-    async def place_call(self, call):
+    async def place_call_by_id(self, device_id: str):
         event = {
             '_type': 'wf_api_call_request',
-            'call': call
+            'device_id': device_id
+        }
+        await self.sendReceive(event)
+
+    async def place_call_by_name(self, device_name: str):
+        event = {
+            '_type': 'wf_api_call_request',
+            'device_name': device_name
         }
         await self.sendReceive(event)

--- a/tests/all_features.py
+++ b/tests/all_features.py
@@ -73,7 +73,8 @@ async def start_handler(relay):
 
     await relay.translate('Bonjour', 'fr-FR', 'en-US')
 
-    await relay.place_call('c')
+    await relay.place_call_by_id('15')
+    await relay.place_call_by_name('n')
 
     await relay.terminate()
 

--- a/tests/test_all_features.py
+++ b/tests/test_all_features.py
@@ -381,14 +381,24 @@ async def handle_translate(ws, xtext, xfrom, xto):
         'to_lang': xto
     })
 
-async def handle_place_call(ws, xcall):
+async def handle_place_call_by_id(ws, xdevice_id):
     e = await recv(ws)
-    check(e, 'wf_api_call_request', call=xcall)
+    check(e, 'wf_api_call_request', device_id=xdevice_id)
 
     await send(ws, {
         '_id': e['_id'],
         '_type': 'wf_api_call_response',
-        'call': xcall,
+        'device_id': xdevice_id,
+    })
+
+async def handle_place_call_by_name(ws, xdevice_name):
+    e = await recv(ws)
+    check(e, 'wf_api_call_request', device_name=xdevice_name)
+
+    await send(ws, {
+        '_id': e['_id'],
+        '_type': 'wf_api_call_response',
+        'device_name': xdevice_name,
     })
 
 async def simple():
@@ -475,7 +485,8 @@ async def simple():
 
         await handle_translate(ws, 'Bonjour', 'fr-FR', 'en-US')
 
-        await handle_place_call(ws, 'c')
+        await handle_place_call_by_id(ws, '15')
+        await handle_place_call_by_name(ws, 'n')
 
         await handle_terminate(ws)
 


### PR DESCRIPTION
Add place_call functionality to py sdk.

Basis: ([relay-js SDK `index.ts line 456-458`](https://github.com/relaypro/relay-js/blob/972bcb50ca167b1963a45a12945842e911b26ef2/src/index.ts#L465))
<img width="491" alt="Screen Shot 2021-07-22 at 9 54 17 AM" src="https://user-images.githubusercontent.com/7386679/126650898-ab5350e6-b4e5-4350-a5ce-9c91790cff1b.png">

Tests:
- Test with placing call by **id** as `15` -> test passing
- Test with placing call by **name** as `n` -> test passing


Note: we decided to split it up into two functions, `place_call_by_name` and `place_call_by_id`. Still routed towards the same `wf_api_call_request`