### PR TITLE
answer_call

### DIFF
--- a/relay/workflow.py
+++ b/relay/workflow.py
@@ -526,3 +526,10 @@ class Relay:
             'device_name': device_name
         }
         await self.sendReceive(event)
+    
+    async def answer_call(self, call_id: str):
+        event = {
+            '_type': 'wf_api_answer_request',
+            'call_id': call_id
+        }
+        await self.sendReceive(event)

--- a/tests/all_features.py
+++ b/tests/all_features.py
@@ -76,6 +76,8 @@ async def start_handler(relay):
     await relay.place_call_by_id('15')
     await relay.place_call_by_name('n')
 
+    await relay.answer_call('15')
+
     await relay.terminate()
 
 

--- a/tests/test_all_features.py
+++ b/tests/test_all_features.py
@@ -401,6 +401,16 @@ async def handle_place_call_by_name(ws, xdevice_name):
         'device_name': xdevice_name,
     })
 
+async def handle_answer_call(ws, xcall_id):
+    e = await recv(ws)
+    check(e, 'wf_api_answer_request', call_id=xcall_id)
+
+    await send(ws, {
+        '_id': e['_id'],
+        '_type': 'wf_api_answer_response',
+        'call_id': xcall_id,
+    })
+
 async def simple():
     uri = "ws://localhost:8765/hello"
     async with websockets.connect(uri) as ws:
@@ -487,6 +497,8 @@ async def simple():
 
         await handle_place_call_by_id(ws, '15')
         await handle_place_call_by_name(ws, 'n')
+
+        await handle_answer_call(ws, '15')
 
         await handle_terminate(ws)
 


### PR DESCRIPTION
Add answer_call functionality to py sdk.

Basis: ([relay-js SDK `index.ts`](https://github.com/relaypro/relay-js/blob/972bcb50ca167b1963a45a12945842e911b26ef2/src/index.ts#L469))
<img width="584" alt="Screen Shot 2021-08-11 at 6 11 48 PM" src="https://user-images.githubusercontent.com/7386679/129112830-c500ad94-d0e6-4410-af00-75948ac9f8a9.png">


Tests:
- Test with answering call with **id** as `15` -> test passing
