### PR TITLE
complete core for hangup-call

### DIFF
--- a/relay/workflow.py
+++ b/relay/workflow.py
@@ -533,3 +533,10 @@ class Relay:
             'call_id': call_id
         }
         await self.sendReceive(event)
+    
+    async def hangup_call(self, call_id: str):
+        event = {
+            '_type': 'wf_api_hangup_request',
+            'call_id': call_id
+        }
+        await self.sendReceive(event)

--- a/tests/all_features.py
+++ b/tests/all_features.py
@@ -77,6 +77,7 @@ async def start_handler(relay):
     await relay.place_call_by_name('n')
 
     await relay.answer_call('15')
+    await relay.hangup_call('15')
 
     await relay.terminate()
 

--- a/tests/test_all_features.py
+++ b/tests/test_all_features.py
@@ -411,6 +411,16 @@ async def handle_answer_call(ws, xcall_id):
         'call_id': xcall_id,
     })
 
+async def handle_hangup_call(ws, xcall_id):
+    e = await recv(ws)
+    check(e, 'wf_api_hangup_request', call_id=xcall_id)
+
+    await send(ws, {
+        '_id': e['_id'],
+        '_type': 'wf_api_hangup_response',
+        'call_id': xcall_id,
+    })
+
 async def simple():
     uri = "ws://localhost:8765/hello"
     async with websockets.connect(uri) as ws:
@@ -499,6 +509,7 @@ async def simple():
         await handle_place_call_by_name(ws, 'n')
 
         await handle_answer_call(ws, '15')
+        await handle_hangup_call(ws, '15')
 
         await handle_terminate(ws)
 


### PR DESCRIPTION
Add hangup_call functionality to py sdk.

Basis: [(relay-js SDK `index.ts`)](https://github.com/relaypro/relay-js/blob/972bcb50ca167b1963a45a12945842e911b26ef2/src/index.ts#L473)
<img width="590" alt="Screen Shot 2021-08-25 at 2 10 59 PM" src="https://user-images.githubusercontent.com/7386679/130843341-766b79bb-a3a3-4e9e-a3c7-66a9982655d6.png">

Tests:
- Test with hangup call with id as 15 -> test passing