### PR TITLE
point to prod servers

### DIFF
--- a/relay/workflow.py
+++ b/relay/workflow.py
@@ -650,7 +650,7 @@ class Relay:
     
                         elif _type == 'wf_api_incident_event':
                             # logger.debug(f"wf_api_incident_event with type: {e['type']}, id: {e['id']}, reason: {e['reason']}")
-                            asyncio.create_task(self.wrapper(h, e['type'], e['id'], e['reason']))
+                            asyncio.create_task(self.wrapper(h, e['type'], e['incident_id'], e['reason']))
     
                         elif _type == 'wf_api_interaction_lifecycle_event':
                             reason = e['reason'] if 'reason' in e else None


### PR DESCRIPTION
- though it affects only the convenience methods for http_trigger
    and get_device_info, point to the prod servers instead of the
    QA servers.
- update the server header (was incorrectly named as User-Agent)
    and remove non-important information about the server's platform.