### PR TITLE
get sample to log by default

### DIFF
--- a/samples/hello_world_wf.py
+++ b/samples/hello_world_wf.py
@@ -6,6 +6,7 @@ import relay.workflow
 import os
 import logging
 
+logging.basicConfig()
 port = os.getenv('PORT', 8080)
 wf_server = relay.workflow.Server('0.0.0.0', port, log_level=logging.INFO)
 hello_workflow = relay.workflow.Workflow('hello workflow')


### PR DESCRIPTION
With the call to logging.basicConfig going away in relay/workflow.py,
move that to the sample, so logging is properly deferred to the app.