### PR TITLE
Fix 404

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: docs
 
 on:
   push:
-    branches: [ fix-404 ]
+    branches: [ main ]
 
   workflow_dispatch:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
       - name: promote
         run: |
           cd web
-          cp -rp ../src/relay/relay.html index.html
+          cp -rp ../src/relay.html index.html
       - uses: EndBug/add-and-commit@v9
         with:
           message: 'publish generated docs'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,6 @@ jobs:
           sudo apt install python3-pip
           pip3 install websockets
           pip3 install requests
-          pip3 install relay
           python generate_docs.py
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,6 @@ jobs:
           sudo apt install python3-pip
           pip3 install websockets
           pip3 install requests
-          cd ../docs
           python generate_docs.py
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: docs
 
 on:
   push:
-    branches: [ main ]
+    branches: [ fix-404 ]
 
   workflow_dispatch:
 
@@ -24,11 +24,11 @@ jobs:
 
       - name: generate markdown and concatenate
         run: |
-          cd src/relay
+          cd src
           sudo apt install python3-pip
           pip3 install websockets
           pip3 install requests
-          pydoc3 -w workflow
+          pydoc3 -w relay
       - uses: actions/checkout@v3
         with:
           ref: 'gh-pages'
@@ -37,7 +37,7 @@ jobs:
       - name: promote
         run: |
           cd web
-          cp -rp ../src/relay/workflow.html index.html
+          cp -rp ../src/relay/relay.html index.html
       - uses: EndBug/add-and-commit@v9
         with:
           message: 'publish generated docs'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,12 +24,11 @@ jobs:
 
       - name: generate markdown and concatenate
         run: |
-          cd src
-          pip3 install relay
-          cd relay
+          cd src/relay
           sudo apt install python3-pip
           pip3 install websockets
           pip3 install requests
+          cd ../docs
           python generate_docs.py
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: docs
 
 on:
   push:
-    branches: [ main ]
+    branches: [ fix-404 ]
 
   workflow_dispatch:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,7 @@ jobs:
           sudo apt install python3-pip
           pip3 install websockets
           pip3 install requests
+          pip3 install relay
           python generate_docs.py
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,11 +24,11 @@ jobs:
 
       - name: generate markdown and concatenate
         run: |
-          cd src
+          cd src/relay
           sudo apt install python3-pip
           pip3 install websockets
           pip3 install requests
-          pydoc3 -w relay
+          python generate_docs.py
       - uses: actions/checkout@v3
         with:
           ref: 'gh-pages'
@@ -37,12 +37,13 @@ jobs:
       - name: promote
         run: |
           cd web
-          cp -rp ../src/relay.html index.html
+          cp -rpv ../src/relay/*.html .
+          cp -pv ../src/relay/workflow.html index.html
       - uses: EndBug/add-and-commit@v9
         with:
           message: 'publish generated docs'
-          add: 'index.html'
           cwd: './web/'
+          add: '.'
           author_name: 'Relay Pro builder'
           author_email: 'info@relaypro.com'
           push: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,9 @@ jobs:
 
       - name: generate markdown and concatenate
         run: |
-          cd src/relay
+          cd src
+          pip3 install relay
+          cd relay
           sudo apt install python3-pip
           pip3 install websockets
           pip3 install requests

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -1,8 +1,10 @@
 import inspect
 import os
-from relay import workflow
+import relay.workflow
 
+os.chdir('../relay')
+os.system('ls')
 os.system('pydoc3 -w workflow')
-for name, obj in inspect.getmembers(workflow):
+for name, obj in inspect.getmembers(relay.workflow):
     if inspect.isclass(obj):
         os.system('pydoc3 -w workflow.%s' % name)

--- a/relay/generate_docs.py
+++ b/relay/generate_docs.py
@@ -5,12 +5,10 @@ import pydoc
 
 p = pydoc.HTMLDoc()
 
-write_html = open("workflow.html", "w")
-write_html.write(p.docmodule(sys.modules["workflow"]))
-write_html.close()
+with open("workflow.html", "w") as write_html:
+    write_html.write(p.docmodule(sys.modules["workflow"]))
 
 for name, obj in inspect.getmembers(workflow):
     if inspect.isclass(obj):
-        write_html = open(name + ".html", "w")
-        write_html.write(p.docclass(obj))
-        write_html.close()
+        with open(name + ".html", "w") as write_html:
+            write_html.write(p.docclass(obj))

--- a/relay/generate_docs.py
+++ b/relay/generate_docs.py
@@ -1,5 +1,6 @@
 import inspect
 import os
+import relay
 from relay import workflow
 
 os.system('pydoc3 -w workflow')

--- a/relay/generate_docs.py
+++ b/relay/generate_docs.py
@@ -1,8 +1,14 @@
 import inspect
-import os
+import sys
 import workflow
+import pydoc
 
-os.system('pydoc3 -w workflow')
+p = pydoc.HTMLDoc()
+func = open("workflow.html", "w")
+func.write(p.docmodule(sys.modules["workflow"]))
+func.close()
 for name, obj in inspect.getmembers(workflow):
     if inspect.isclass(obj):
-        os.system('pydoc3 -w workflow.%s' % name)
+        func = open(name + ".html", "w")
+        func.write(p.docclass(obj))
+        func.close()

--- a/relay/generate_docs.py
+++ b/relay/generate_docs.py
@@ -1,0 +1,8 @@
+import inspect
+import os
+from relay import workflow
+
+os.system('pydoc3 -w workflow')
+for name, obj in inspect.getmembers(workflow):
+    if inspect.isclass(obj):
+        os.system('pydoc3 -w workflow.%s' % name)

--- a/relay/generate_docs.py
+++ b/relay/generate_docs.py
@@ -4,11 +4,13 @@ import workflow
 import pydoc
 
 p = pydoc.HTMLDoc()
-func = open("workflow.html", "w")
-func.write(p.docmodule(sys.modules["workflow"]))
-func.close()
+
+write_html = open("workflow.html", "w")
+write_html.write(p.docmodule(sys.modules["workflow"]))
+write_html.close()
+
 for name, obj in inspect.getmembers(workflow):
     if inspect.isclass(obj):
-        func = open(name + ".html", "w")
-        func.write(p.docclass(obj))
-        func.close()
+        write_html = open(name + ".html", "w")
+        write_html.write(p.docclass(obj))
+        write_html.close()

--- a/relay/generate_docs.py
+++ b/relay/generate_docs.py
@@ -1,6 +1,5 @@
 import inspect
 import os
-import relay
 from relay import workflow
 
 os.system('pydoc3 -w workflow')

--- a/relay/generate_docs.py
+++ b/relay/generate_docs.py
@@ -1,10 +1,8 @@
 import inspect
 import os
-import relay.workflow
+import workflow
 
-os.chdir('../relay')
-os.system('ls')
 os.system('pydoc3 -w workflow')
-for name, obj in inspect.getmembers(relay.workflow):
+for name, obj in inspect.getmembers(workflow):
     if inspect.isclass(obj):
         os.system('pydoc3 -w workflow.%s' % name)


### PR DESCRIPTION
For ticket [PE-19874](https://republic-bts.atlassian.net/browse/PE-19874), added a module generate_docs that generates HTML pages by calling pydoc3 for each class in workflows as well as for the workflows module itself.  404 error appears to be fixed for all class links on https://relaypro.github.io/relay-py/ .